### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is a repository for home page for [Kleo Network](https://www.kleo.network/)
 
 ## Tasks
-- [ ] Remove unecessary components and files in the repository.
+- [ ] Remove unnecessary components and files in the repository.
 - [ ] Improve Call to Action on homepage - Add video! 
 - [ ] Add a section - "Some things can be public"
 - [ ] Add a section - "Other things need to be private"

--- a/src/components/_old_home/sections/Footer.tsx
+++ b/src/components/_old_home/sections/Footer.tsx
@@ -70,7 +70,7 @@ export const Footer = () => {
             © 2023 KLEO. All rights reserved.
           </div>
           <div className="justify-start items-center gap-6 flex">
-            <a href="https://twitter.com/kleo_network" target="_blank">
+            <a href="https://x.com/kleo_network" target="_blank">
               <XIcon className="w-6 h-6 relative" />
             </a>
             <a

--- a/src/components/profile/Onboarding/SocialSharePopUp.tsx
+++ b/src/components/profile/Onboarding/SocialSharePopUp.tsx
@@ -41,7 +41,7 @@ const SocialShare: React.FC<SocialShareProps> = ({ profileUrl }) => {
 
   const shareToTwitter = () => {
     window.open(
-      `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+      `https://x.com/intent/tweet?text=${encodeURIComponent(
         shareMessage
       )}`
     )

--- a/src/shared/navbar/Navbar.tsx
+++ b/src/shared/navbar/Navbar.tsx
@@ -63,7 +63,7 @@ const Navbar = () => {
         </a>
         <a
           className="hover:underline hover:underline-offset-4 pointer-events-auto"
-          href="https://twitter.com/kleo_network"
+          href="https://x.com/kleo_network"
           target="_blank"
         >
           Twitter ↗
@@ -122,7 +122,7 @@ const Navbar = () => {
         </a>
         <a
           className="block hover:underline pointer-events-auto"
-          href="https://twitter.com/kleo_network"
+          href="https://x.com/kleo_network"
           target="_blank"
         >
           Twitter ↗


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.